### PR TITLE
Support batched expression rendering with cached source gaussians

### DIFF
--- a/gagavatar/models/GAGAvatar/models.py
+++ b/gagavatar/models/GAGAvatar/models.py
@@ -69,6 +69,19 @@ class GAGAvatar(nn.Module):
 
     @torch.no_grad()
     def forward_expression(self, batch):
+        gs_params = self.forward_gaussians(batch)
+        t_image, t_transform = batch['t_image'], batch['t_transform']
+        gen_images = render_gaussian(
+            gs_params=gs_params, cam_matrix=t_transform, cam_params=self.cam_params
+        )['images']
+        sr_gen_images = self.upsampler(gen_images)
+        results = {
+            't_image':t_image, 'gen_image': gen_images[:, :3], 'sr_gen_image': sr_gen_images,
+        }
+        return results
+
+    @torch.no_grad()
+    def forward_gaussians(self, batch):
         if not hasattr(self, '_gs_params'):
             batch_size = batch['f_image'].shape[0]
             f_image, f_planes = batch['f_image'], batch['f_planes']
@@ -92,17 +105,21 @@ class GAGAvatar(nn.Module):
                 k:torch.cat([gs_params_g[k], gs_params_l0[k], gs_params_l1[k]], dim=1) for k in gs_params_g.keys()
             }
             self._gs_params = gs_params
-        gs_params = self._gs_params
-        t_image, t_points, t_transform = batch['t_image'], batch['t_points'], batch['t_transform']
-        gs_params['xyz'][:, :5023] = t_points
-        gen_images = render_gaussian(
-            gs_params=gs_params, cam_matrix=t_transform, cam_params=self.cam_params
-        )['images']
-        sr_gen_images = self.upsampler(gen_images)
-        results = {
-            't_image':t_image, 'gen_image': gen_images[:, :3], 'sr_gen_image': sr_gen_images,
+        t_points = batch['t_points']
+        batch_size = t_points.shape[0]
+        cached = self._gs_params
+        # xyz is overwritten per driving frame below, so it needs a real copy
+        # per batch element; the other parameters are identical across frames
+        # and the rasterizer consumes per-element views, so zero-copy expanded
+        # views suffice.
+        xyz = cached['xyz'].expand(batch_size, -1, -1).clone()
+        xyz[:, :5023] = t_points
+        gs_params = {
+            key: value.expand(batch_size, *value.shape[1:])
+            for key, value in cached.items() if key != 'xyz'
         }
-        return results
+        gs_params['xyz'] = xyz
+        return gs_params
 
     def calc_metrics(self, results):
         loss_fn = nn.functional.l1_loss


### PR DESCRIPTION
Part 3 of the upstreaming sequence in #62.

`forward_expression` computed the source-image gaussians once but could only render one driving frame per call, and it mutated the cached gaussians' `xyz` in place. This splits source-gaussian construction into `forward_gaussians` (still cached after the first call) and expands the cached parameters to the driving batch size, so N driving frames render in one call. That is the enabler for realtime use: at batch size 1, per-call Python and kernel-launch overhead dominates render time.

Only `xyz` is materialized per batch element (it is overwritten with each frame's FLAME points); the other cached parameters are shared across frames as zero-copy expanded views, which the rasterizer consumes per-element. The cache itself is never mutated anymore.

Verified:
- `python inference.py -d ./demos/drivers/obama -i ./demos/examples/1.jpg` unchanged end to end (241-frame mp4, exit 0).
- Direct batched test: a driver batch expanded to N=4 renders `(4, 3, 512, 512)` in one `forward_expression` call. Batched output matches per-frame output within 7e-3 max abs — the same order as the rasterizer's inherent run-to-run variance (4e-3 between two identical calls, from atomic accumulation), i.e. batching adds no error of its own.
- The cached source gaussians are bit-identical before and after rendering calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)